### PR TITLE
Add no-as-needed compile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all: libfreebindfree.so
 
 lib%.so: %.c
-	gcc -shared -o $@ -ldl $< -fPIC
+	gcc -shared -Wl,--no-as-needed -o $@ -ldl $< -fPIC


### PR DESCRIPTION
This fixes a symbol lookup error:
`symbol lookup error: /home/appservice-irc/freebindfree/libfreebindfree.so: undefined symbol: dlsym`
as described in https://stackoverflow.com/questions/20369672/undefined-reference-to-dlsym/20419191#20419191